### PR TITLE
regex modification in nrpe config parser allows spaces before and after "="

### DIFF
--- a/agent/nrpe.rb
+++ b/agent/nrpe.rb
@@ -67,7 +67,7 @@ module MCollective
           File.readlines(fname).each do |check|
             check.chomp!
 
-            if check =~ /command\[#{command}\]=(.+)$/
+            if check =~ /command\[#{command}\]\s*=\s*(.+)$/
               ret = {:cmd => $1}
             end
           end


### PR DESCRIPTION
Hey there,

These are both valid nrpe configuration lines, but the code base currently only matches the second example:

```
command[check_apt] = /usr/lib/nagios/plugins/check_apt
command[check_apt]=/usr/lib/nagios/plugins/check_apt
```

  The regex modification allows both to match.
