### PR TITLE
Add runallcommands action to NRPE agent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+
+gem 'mcollective'
+
+group :dev do
+  gem 'rake'
+end
+
+group :test do
+  gem 'mcollective-test'
+  gem 'rdoc'
+  gem 'rspec', '~> 2.11.0'
+  gem 'mocha', '~> 0.10.0'
+end
+


### PR DESCRIPTION
This allows you to run every command that the remote machine knows
about, allowing you to assert it's nrpe status. This is useful
(for example) when you're building an environment, and you want to
assert base machines (e.g. dns servers) can be tested before you've
actually built the nagios server.
