### PR TITLE
Added a more flexible way of pulling commands from .cfg files while main...

### DIFF
--- a/agent/nrpe.rb
+++ b/agent/nrpe.rb
@@ -51,7 +51,6 @@ module MCollective
       end
 
       def self.plugin_for_command(command)
-        ret = nil
         fnames = []
         config = Config.instance
 
@@ -74,7 +73,7 @@ module MCollective
             end
           end
         end
-
+        nil
       end
     end
   end


### PR DESCRIPTION
"#{fdir}/#{command}.cfg" isn't compatible with multiple commands per file. This will allow the agent to be used in the same manner while also allowing for multiple commands per file in fdir.
