### PR TITLE
Fully qualify call to MCollective::Shell.new

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ rvm:
   - 1.9.3
 env:
   matrix:
-    - MCOLLECTIVE_GEM_VERSION="~> 2.2.0"
-    - MCOLLECTIVE_GEM_VERSION="~> 2.4.0"
     - MCOLLECTIVE_GEM_VERSION="~> 2.5.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.6.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.7.0"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ rvm:
   - 1.9.3
 env:
   matrix:
-    - MCOLLECTIVE_GEM_VERSION ="~> 2.2.0"
-    - MCOLLECTIVE_GEM_VERSION ="~> 2.4.0"
-    - MCOLLECTIVE_GEM_VERSION ="~> 2.5.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.2.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.4.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.5.0"
 notifications:
   email: false

--- a/agent/nrpe.rb
+++ b/agent/nrpe.rb
@@ -43,7 +43,7 @@ module MCollective
         return 3, "No such command: #{command}" unless nrpe_command
 
         output = ""
-        shell = Shell.new(nrpe_command[:cmd], {:stdout => output, :chomp => true})
+        shell = ::MCollective::Shell.new(nrpe_command[:cmd], {:stdout => output, :chomp => true})
         shell.runcommand
         exitcode = shell.status.exitstatus
 


### PR DESCRIPTION
In cases where the nrpe agent is installed alongside the shell agent
the call to Shell.new resolves to the closer MCollective::Agent::Shell
rather than the intended MCollective::Shell.   This commit removes
the relative class resolution to make it absolute.