### PR TITLE
Added parameters support to MCO NRPE Agent

### DIFF
--- a/agent/nrpe.ddl
+++ b/agent/nrpe.ddl
@@ -17,6 +17,14 @@ action "runcommand", :description => "Run a NRPE command" do
           :optional    => false,
           :maxlength   => 50
 
+    input :args,
+          :prompt      => "Arguments",
+          :description => "NRPE Command arguments",
+          :type        => :string,
+          :validation  => '.*',
+          :optional    => true,
+          :maxlength   => 50
+
     output :output,
            :description => "Output from the Nagios plugin",
            :display_as  => "Output",


### PR DESCRIPTION
- Added new input parameter named :args. In which we can
  specify all nrpe arguments that will be replace on defined
  nrpe check_command before executing it on shell.

- :args is a string formed with all arguments separated by "!" like
  nagios command definition.