### PR TITLE
Add runallcommands to NRPE agent

### DIFF
--- a/agent/nrpe.ddl
+++ b/agent/nrpe.ddl
@@ -44,3 +44,8 @@ action "runcommand", :description => "Run a NRPE command" do
     end
 end
 
+action "runallcommands", :description => "Run all defined NRPE commands" do
+    output :commands,
+           :description => "Output status of all defined commands",
+           :display_as  => "Commands"
+end

--- a/agent/nrpe.rb
+++ b/agent/nrpe.rb
@@ -56,17 +56,19 @@ module MCollective
         return 3, "No such command: #{command}" unless nrpe_command
 
         output = ""
-        shell = ::MCollective::Shell.new(nrpe_command[:cmd], {:stdout => output, :chomp => true})
+        shell = ::MCollective::Shell.new(nrpe_command, {:stdout => output, :chomp => true})
         shell.runcommand
         exitcode = shell.status.exitstatus
         return exitcode, output
       end
 
       def self.plugin_for_command(command)
-        plugin = Nrpe.all_command_plugins[command]
-        if plugin
-          return { :cmd => plugin }
+        plugins = Nrpe.all_command_plugins
+
+        if plugins.include?(command)
+          return plugins[command]
         end
+
         return nil
       end
 

--- a/agent/nrpe.rb
+++ b/agent/nrpe.rb
@@ -2,6 +2,19 @@ module MCollective
   module Agent
     class Nrpe<RPC::Agent
 
+      action "runallcommands" do
+        reply[:commands] = {}
+        p = Nrpe.all_command_plugins
+        p.each do |name,cmd|
+          exitcode, output = Nrpe.run(name)
+
+          reply[:commands][name] = {
+            :exitcode => exitcode,
+            :output => output,
+          }
+        end
+      end
+
       action "runcommand" do
         reply[:exitcode], reply[:output] = Nrpe.run(request[:command])
         reply[:command] = request[:command]
@@ -46,11 +59,19 @@ module MCollective
         shell = ::MCollective::Shell.new(nrpe_command[:cmd], {:stdout => output, :chomp => true})
         shell.runcommand
         exitcode = shell.status.exitstatus
-
         return exitcode, output
       end
 
       def self.plugin_for_command(command)
+        plugin = Nrpe.all_command_plugins[command]
+        if plugin
+          return { :cmd => plugin }
+        end
+        return nil
+      end
+
+      def self.all_command_plugins
+        commands = {}
         fnames = []
         config = Config.instance
 
@@ -67,13 +88,14 @@ module MCollective
             File.readlines(fname).each do |check|
               check.chomp!
 
-              if check =~ /command\[#{command}\]\s*=\s*(.+)$/
-                return {:cmd => $1}
+              if check =~ /^command\[(.+?)\]\s*=\s*(.+)$/
+                commands[$1] = $2
               end
             end
           end
         end
-        nil
+
+        return commands
       end
     end
   end

--- a/spec/agent/nrpe_agent_spec.rb
+++ b/spec/agent/nrpe_agent_spec.rb
@@ -55,7 +55,7 @@ describe "nrpe agent" do
     it "should return the command from nrpe.conf_dir if it is set" do
       File.expects(:exist?).with("/foo/bar.cfg").returns(true)
       File.expects(:readlines).with("/foo/bar.cfg").returns(["command[command]=run"])
-      MCollective::Agent::Nrpe.plugin_for_command("command").should == {:cmd => "run"}
+      MCollective::Agent::Nrpe.plugin_for_command("command").should == "run"
     end
 
     it "should return the command from nrpe.conf_dir if it is set and nrpe.conf_file is unset" do
@@ -65,7 +65,7 @@ describe "nrpe agent" do
       File.expects(:readlines).with("/foo/baz.cfg").returns(["command[fake_command]=donotrun"])
       File.expects(:exist?).with("/foo/bar.cfg").returns(true)
       File.expects(:readlines).with("/foo/bar.cfg").returns(["command[other_fake_command]=donotrun", "command[command]=run"])
-      MCollective::Agent::Nrpe.plugin_for_command("command").should == {:cmd => "run"}
+      MCollective::Agent::Nrpe.plugin_for_command("command").should == "run"
     end
 
     it "should return the nil if no matching command is found in nrpe.conf_dir" do
@@ -80,7 +80,7 @@ describe "nrpe agent" do
       pluginconf["nrpe.conf_dir"] = nil
       File.expects(:exist?).with("/etc/nagios/nrpe.d/bar.cfg").returns(true)
       File.expects(:readlines).with("/etc/nagios/nrpe.d/bar.cfg").returns(["command[command]=run"])
-      MCollective::Agent::Nrpe.plugin_for_command("command").should == {:cmd => "run"}
+      MCollective::Agent::Nrpe.plugin_for_command("command").should == "run"
     end
   end
 

--- a/spec/agent/nrpe_agent_spec.rb
+++ b/spec/agent/nrpe_agent_spec.rb
@@ -103,4 +103,25 @@ describe "nrpe agent" do
       MCollective::Agent::Nrpe.run("foo").should == [3, "No such command: foo"]
     end
   end
+
+  describe "#runallcommands" do
+    let(:config){mock}
+    let(:pluginconf){{"nrpe.conf_dir" => "/foo", "nrpe.conf_file" => "bar.cfg"}}
+
+    before :each do
+      config.stubs(:pluginconf).returns(pluginconf)
+      MCollective::Config.stubs(:instance).returns(config)
+      File.expects(:exist?).with("/foo/bar.cfg").returns(true)
+      File.expects(:readlines).with("/foo/bar.cfg").returns(["command[command]=run"])
+    end
+
+    it "should reply with statusmessage 'OK' of exitcode is 0" do
+      MCollective::Agent::Nrpe.expects(:run).with("command").returns(0)
+      result = @agent.call(:runallcommands, :command => "command")
+      result.should be_successful
+      result.should have_data_items(:commands=>{"command"=>{:exitcode=>0, :output=>nil}})
+      result[:statusmsg].should == "OK"
+      result[:statuscode].should == 0
+    end
+  end
 end


### PR DESCRIPTION
Here we add a runallcommands action to the nrpe agent.   

This was originally proposed as PR#5 but it fell down a crack in the review process.  94a9bed is from that PR with some minor cleanup.