### PR TITLE
Fix Nrpe data plugin to work with Nrpe agent args

### DIFF
--- a/data/nrpe_data.rb
+++ b/data/nrpe_data.rb
@@ -6,10 +6,9 @@ module MCollective
       activate_when{ PluginManager["nrpe_agent"] }
 
       query do |command|
-        nrpe_command = Agent::Nrpe.plugin_for_command(command)
+        nrpe_command = Agent::Nrpe.plugin_for_command(command, [])
 
         if nrpe_command
-          nrpe_command = nrpe_command[:cmd]
           Log.debug("Running Nrpe command '#{command}' : '#{nrpe_command}'")
           result[:exitcode], _ = Agent::Nrpe.run(command)
         else


### PR DESCRIPTION
Commit d497e402251ac354057ce12ec7fbe01e123aa141 changed the call parameters of plugin_for_command and the return value format.

using mcollective nrpe data plugin:
mco rpc rpcutil ping -S "Nrpe('check_something').exitcode=0"
we got the following error:
Failed to handle message: wrong number of arguments (1 for 2) - ArgumentError
/usr/share/mcollective/plugins/mcollective/agent/nrpe.rb:66:in plugin_for_command' /usr/share/mcollective/plugins/mcollective/data/nrpe_data.rb:9:inblock in class:Nrpe_data'
...

I think this commit makes the data plugin work again.