### PR TITLE
add support for plugin.nrpe.conf_path

### DIFF
--- a/agent/nrpe.rb
+++ b/agent/nrpe.rb
@@ -90,6 +90,8 @@ module MCollective
 
         if config.pluginconf["nrpe.conf_file"]
           fnames << "#{fdir}/#{config.pluginconf['nrpe.conf_file']}"
+        elsif config.pluginconf["nrpe.conf_path"]
+          fnames |= Dir.glob(config.pluginconf["nrpe.conf_path"].split(':').map{|fdir| "#{fdir}/*.cfg"})
         else
           fnames |= Dir.glob("#{fdir}/*.cfg")
         end


### PR DESCRIPTION
This allows you to specify more than one directory where
the NRPE cfg files live. Directories are separated by a colon.
E.g. /foo/bar:/another/foo/bar

Our infrastructure uses multiple nrpe.cfg files in different directories:
/usr/local/nagios/etc/nrpe.cfg
/usr/local/nagios/etc/nrpe_local/nrpe_local.cfg
The second directory is included via the include_dir directive in the first nrpe.cfg
Our second file is managed by puppet.

To support such a setup, I supply this branch with support for a config named plugin.nrpe.conf_path, which can be used instead of plugin.nrpe.conf_dir to supply multiple directories.

Other solutions would be to provide such a path in plugin.nrpe.conf_dir and treat it as a path if one or more colons are present or to parse the config files in config_dir for include_dir directives. The implemented solution (via config_path) is IMHO the cleanest (because it leaves config_dir behavior untouched) and easiest (because it needs no complicted parsing of nrpe.cfg files) of the three solutions.