### PR TITLE
add args to nrpe data plugin

### DIFF
--- a/agent/nrpe.rb
+++ b/agent/nrpe.rb
@@ -63,7 +63,7 @@ module MCollective
         return exitcode, output
       end
 
-      def self.plugin_for_command(command, args)
+      def self.plugin_for_command(command, args=[])
         plugins = Nrpe.all_command_plugins
 
         if plugins.include?(command)

--- a/data/nrpe_data.ddl
+++ b/data/nrpe_data.ddl
@@ -13,7 +13,7 @@ dataquery :description => "Runs a Nrpe command and returns the exit code" do
           :prompt       => "Command",
           :description  => "Valid Nrpe command",
           :type         => :string,
-          :validation   => '\A[a-zA-Z0-9_-]+\z',
+          :validation   => '\A[a-zA-Z0-9_-]+( .*)?\z',
           :maxlength    => 20
 
   output  :exitcode,

--- a/data/nrpe_data.rb
+++ b/data/nrpe_data.rb
@@ -6,7 +6,13 @@ module MCollective
       activate_when{ PluginManager["nrpe_agent"] }
 
       query do |command|
-        nrpe_command = Agent::Nrpe.plugin_for_command(command, [])
+        if command =~ / /
+          args = command.split(' ', 2)[1].split('!')
+          command = command.split(' ', 2)[0]
+        else
+          args = []
+        end
+        nrpe_command = Agent::Nrpe.plugin_for_command(command, args)
 
         if nrpe_command
           Log.debug("Running Nrpe command '#{command}' : '#{nrpe_command}'")


### PR DESCRIPTION
Commit d497e40 gave us the ability to use an argument string (with all arguments separated by "!" like
  nagios command definition) with the MCollective NRPE agent. This commit should do the same for the MCollective NRPE data plugin.